### PR TITLE
Fixture for issue #14 - jsdoc() wrong handling of optional parameters…

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,12 @@ Set env variable: ```DEBUG=gulp-jsdoc3```
 
 ## Notes
 This is a reasonable attempt to wrap jsdoc using gulp as thinly as possible. All files are added after the cli.
-i.e. jsdoc -c config -t node_modules/ink-docstrap/template gulpFile1 gulpFile2  
+i.e. `jsdoc -c config -t node_modules/ink-docstrap/template gulpFile1 gulpFile2`  
 [jsdoc](https://github.com/jsdoc3/jsdoc) does not allow for piped input, so this attempt may be considered a gulp
 anti-pattern. It also does not pass on output to be piped elsewhere.
 
 
-I would like to thank Mangled Deutz @ [gulp-jsdoc](https://github.com/jsBoot/gulp-jsdoc) for the original implimentation.
+I would like to thank Mangled Deutz @ [gulp-jsdoc](https://github.com/jsBoot/gulp-jsdoc) for the original implementation.
 
 License
 -------------

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "bluebird": "^3.1.1",
     "debug": "^2.2.0",
     "gulp-util": "^3.0.7",
-    "ink-docstrap": "^1.0.2",
+    "ink-docstrap": "^1.1.4",
     "jsdoc": "^3.4.0",
     "map-stream": "0.0.6",
     "tmp": "0.0.28"

--- a/src/gulp-jsdoc.js
+++ b/src/gulp-jsdoc.js
@@ -31,7 +31,7 @@ export function jsdoc(config, done) {
     let jsdocConfig;    
 
     // User just passed callback
-    if(arguments.length === 1 && typeof done !== 'function'){
+    if (arguments.length === 1 && typeof config === 'function') {
         done = config;
         config = undefined;
     }

--- a/test/gulp-jsdoc_spec.js
+++ b/test/gulp-jsdoc_spec.js
@@ -7,6 +7,7 @@ import gulp from 'gulp';
 import tmp from 'tmp';
 import path from 'path';
 import mockSpawn from 'mock-spawn';
+import Promise from 'bluebird';
 
 let mySpawn = mockSpawn();
 
@@ -99,6 +100,26 @@ describe('gulp-jsdoc', function () {
                 cb();
             };
             gulp.src([__dirname + '/testFile.js']).pipe(jsdoc(config, done));
+        });
+
+        it('Should document files with a custom layout if no callback provided', function (cb) {
+            config.templates.default.layoutFile = path.resolve('./test/layout.tmpl');
+
+            Promise.all(gulp.src([__dirname + '/testFile.js']).pipe(jsdoc(config)))
+                .then(function() {
+                    const stats = fs.statSync(config.opts.destination);
+                    expect(stats.isDirectory()).to.be.true;
+                    expect(fs.readFileSync(config.opts.destination + '/testFile.js.html', 'utf-8'))
+                        .to.contain('JSDocTesting');
+                    expect(fs.readFileSync(config.opts.destination + '/module-JSDocTesting.html', 'utf-8'))
+                        .to.contain('inputDataHere');
+                })
+                .catch(function (err) {
+                    expect(err).not.to.exist;
+                })
+                .finally(function() {
+                    cb();
+                });
         });
     });
 


### PR DESCRIPTION
…. Added test case.

Fixed typo in README
Updated to dependency "ink-docstrap" to current release