### PR TITLE
Fix logic: if user did not specify their own layout or template

### DIFF
--- a/src/gulp-jsdoc.js
+++ b/src/gulp-jsdoc.js
@@ -75,7 +75,7 @@ export function jsdoc(config, done) {
 
                 // Config + ink-docstrap if user did not specify their own layout or template
                 if (!(jsdocConfig.opts &&
-                    jsdocConfig.opts.template) || !(jsdocConfig.templates &&
+                    jsdocConfig.opts.template) && !(jsdocConfig.templates &&
                     jsdocConfig.templates.default &&
                     jsdocConfig.templates.default.layoutFile)) {
                     args = args.concat(['-t', inkdocstrap]);


### PR DESCRIPTION
This change allows using a `template` without the need to define a `layout` file too, and vice versa.
Just a little fix in logic. I don't think it was your intention to force the definition of both a `template` and a `layout` file to overwrite the `ink-docstrap` theme.