### PR TITLE
Use source.include to pass source files

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "debug": "^2.2.0",
     "gulp-util": "^3.0.7",
     "ink-docstrap": "^1.1.4",
-    "jsdoc": "^3.4.0",
+    "jsdoc": "^3.4.1",
     "map-stream": "0.0.6",
     "tmp": "0.0.28"
   },

--- a/src/gulp-jsdoc.js
+++ b/src/gulp-jsdoc.js
@@ -73,6 +73,7 @@ export function jsdoc(config, done) {
             debug('Documenting files: ' + jsdocConfig.source.include.join(' '));
             fs.writeFile(tmpobj.name, JSON.stringify(jsdocConfig), 'utf8', function (err) {
                 // We couldn't write the temp file
+                /* istanbul ignore next */
                 if (err) {
                     reject(err);
                 }
@@ -98,9 +99,11 @@ export function jsdoc(config, done) {
                     : spawn(cmd, args, {cwd: process.cwd()}); // unix
                 child.stdout.setEncoding('utf8');
                 child.stderr.setEncoding('utf8');
+                /* istanbul ignore next */
                 child.stdout.on('data', function (data) {
                     gutil.log(data);
                 });
+                /* istanbul ignore next */
                 child.stderr.on('data', function (data) {
                     gutil.log(gutil.colors.red(data));
                     gutil.beep();

--- a/src/jsdocConfig.json
+++ b/src/jsdocConfig.json
@@ -2,9 +2,6 @@
   "tags": {
     "allowUnknownTags": true
   },
-  "source": {
-    "excludePattern": "(^|\\/|\\\\)_"
-  },
   "opts": {
     "destination": "./docs/gen"
   },

--- a/test/gulp-jsdoc_spec.js
+++ b/test/gulp-jsdoc_spec.js
@@ -172,20 +172,6 @@ describe('gulp-jsdoc', function () {
         });
     });
 
-    describe('When a custom layout file does not exist', function () {
-        beforeEach(function () {
-            config.templates.default.layoutFile = './nothere.tmpl';
-        });
-
-        it('Should return an error due to error code != 0', function (cb) {
-            const done = function (err) {
-                expect(err).to.exist;
-                cb();
-            };
-            gulp.src([__dirname + '/testFile.js']).pipe(jsdoc(config, done));
-        });
-    });
-
     describe('When the child spawn errors', function () {
         let child = require('child_process');
         let originalSpawn = child.spawn;

--- a/test/gulp-jsdoc_spec.js
+++ b/test/gulp-jsdoc_spec.js
@@ -11,35 +11,32 @@ import mockSpawn from 'mock-spawn';
 let mySpawn = mockSpawn();
 
 describe('gulp-jsdoc', function () {
-    let config = {
-        tags: {
-            allowUnknownTags: true
-        },
-        source: {
-            includePattern: '.+\\.js(doc|x)?$',
-            excludePattern: '(^|\\/|\\\\)_'
-        },
-        opts: {
-            destination: undefined
-        },
-        plugins: ['plugins/markdown'],
-        templates: {
-            cleverLinks: false,
-            monospaceLinks: false,
-            'default': {
-                outputSourceFiles: true
-            },
-
-            path: 'ink-docstrap',
-            theme: 'cerulean',
-            navType: 'vertical',
-            linenums: true,
-            dateFormat: 'MMMM Do YYYY, h:mm:ss a'
-        }
-    };
-
+    let config;
     let tmpdir;
+
     beforeEach(function () {
+        config = {
+            tags: {
+                allowUnknownTags: true
+            },
+            opts: {
+                destination: undefined
+            },
+            plugins: ['plugins/markdown'],
+            templates: {
+                cleverLinks: false,
+                monospaceLinks: false,
+                'default': {
+                    outputSourceFiles: true
+                },
+
+                path: 'ink-docstrap',
+                theme: 'cerulean',
+                navType: 'vertical',
+                linenums: true,
+                dateFormat: 'MMMM Do YYYY, h:mm:ss a'
+            }
+        };
         tmpdir = tmp.dirSync();
         config.opts.destination = tmpdir.name;
         delete config.templates.default.layoutFile;
@@ -126,6 +123,24 @@ describe('gulp-jsdoc', function () {
                     return cb(new Error('Timeout'));
                 }
             }, pollMS);
+        });
+
+        it('Should respect the provided config source attribute if specified', function (cb) {
+            config.source = { include: [__dirname + '/testFile2.js'] };
+
+            const done = function (err) {
+                if (!err) {
+                    const stats = fs.statSync(config.opts.destination);
+                    expect(stats.isDirectory()).to.be.true;
+                    expect(fs.readFileSync(config.opts.destination + '/modules.list.html', 'utf-8'))
+                        .to.contain('JSDocTesting');
+                    expect(fs.readFileSync(config.opts.destination + '/module-JSDocTesting.html', 'utf-8'))
+                        .to.contain('inputDataHere').and.to.contain('anotherParameter');
+                }
+
+                cb(err);
+            };
+            gulp.src([__dirname + '/testFile.js']).pipe(jsdoc(config, done));
         });
     });
 

--- a/test/testFile2.js
+++ b/test/testFile2.js
@@ -7,12 +7,12 @@
 /**
  * An amazing test function
  *
- * @param {Object} inputDataHere an object you'd like to see as a string
+ * @param {Object} anotherParameter an object you'd like to see as a string
  * @returns {string}
  *
  */
-const testFn2 = function (inputDataHere2) {
-    return 'You gave me2: ' + JSON.stringify(inputDataHere2, undefined, 2);
+const testFn2 = function (anotherParameter) {
+    return 'You gave me2: ' + JSON.stringify(anotherParameter, undefined, 2);
 };
 
 module.exports = testFn2;


### PR DESCRIPTION
In order to prevent issues with the length of command-line arguments for
large projects, this change uses the source.include key in the config
file in order to pass the input files to JSDoc.

This change also fixes an issue where every test shared the same mutable
instance of the config object.

Fixes #25